### PR TITLE
Add onProgress, importCourseAsync and getAsyncImportResult APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "md5": "^2.2.1",
     "moment": "^2.21.0",
     "request": "^2.87.0",
+    "request-progress": "^3.0.0",
     "xml2js": "^0.4.19"
   },
   "devDependencies": {},


### PR DESCRIPTION
This lets clients check the progress of their often multi-gigabyte uploads.

add request-progress to deps

This is needed to monitor request progress for file uploads, such as importCourse.

fix: add correct pointer into request-progress

add importCourseAsync and getAsyncImportResult APIs